### PR TITLE
chore(deps): security audit fix 2026-07-09

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -779,13 +779,13 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.17.tgz",
-      "integrity": "sha512-KithZ3b0HBFH0NbUcswBcjpN9y09vLbarMD7qmGWTnGUBk4W8cn4sbT8zJyv9CRKg9ZcuUBeJYKUfUPn/u/5OQ==",
+      "version": "21.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.18.tgz",
+      "integrity": "sha512-L5zbIp7YfTTB4I4xT33FgEBanzhppNejzZX0HJOEqKDyDL2jXq+flt83lE0XVuRJ6/zrG+UKj0B+y/CK6Ro7Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "7.29.0",
+        "@babel/core": "7.29.7",
         "@jridgewell/sourcemap-codec": "^1.4.14",
         "chokidar": "^5.0.0",
         "convert-source-map": "^1.5.1",
@@ -802,61 +802,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.17",
+        "@angular/compiler": "21.2.18",
         "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@angular/core": {


### PR DESCRIPTION
## Security Audit Fix

**Status:** Partial auto-fixes applied via `npm audit fix` (lock file cleanup). HIGH vulnerabilities still require a manual semver major bump — see below.

**Vulnerabilities found:**
- `http-proxy-middleware` [HIGH] — multipart/form-data CRLF injection: https://github.com/advisories/GHSA-gcq2-9pq2-cxqm
- `http-proxy-middleware` [HIGH] — Host-header-driven backend routing bypass: https://github.com/advisories/GHSA-64mm-vxmg-q3vj

**Manual fixes still needed:**
- Update `@angular-devkit/build-angular` to `19.2.8` (semver major — run `npm audit fix --force` after verifying breaking changes are acceptable)

Generated by /security-scan agent.