### PR TITLE
chore(deps): security audit fix 2026-08-04

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.17.tgz",
-      "integrity": "sha512-hqAQxRfi5ldFE42suAXRcY+JCANrUh7fuSQ/DtZ7L896id5BT/exuv6dWNBC1PyAfQmRbpD5Pt6/pd+tNLyhDQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.19.tgz",
+      "integrity": "sha512-Rvo/VXI0kUmfQT7+OeAjv526OJlf/WrLnJq1Tz84Jkyv9bs9SOMTCT6m4+boo8gxVNdrcxvGU3Q0o2jZzKceSg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -621,14 +621,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.17",
+        "@angular/core": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.17.tgz",
-      "integrity": "sha512-p+NdjYiwAz9Zmu2yul0LlMXaFjMISVVa24+/MVMoKFeQeI82QE8jDywPlnOSHQHvdCcQVpS7saeEriZzX3JuBQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.19.tgz",
+      "integrity": "sha512-vuF5i1t14ftJiHXVVLgDYLWkT99QuajphcUHy1VZaMX3FiqSGXRV62g+R2RMxL0OJ5C1ai8xTHKPx9n1lQFyFg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-wYHpwIdnUnjQFOJJNqRcGx7LS3u64jT+R9L0TnMR/ViBM9dQgGYImlSikkftg2yrFCNo5aKRxhG2LLskQurVdg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-PVoXD1kBexOJLkFzKx2zBY/0oZJXGru0eGn2hu0q5n3vkZlYsR1yRolfGenK1gZE48Qibiw/ttg/X/pAIPEZGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -682,7 +682,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.17",
+        "@angular/compiler": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@angular/platform-server": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-21.2.17.tgz",
-      "integrity": "sha512-ll5mbZHyUjZp+aL5eFCcusZBMLYv2fbxuPAIhAHFpu55kC9zh7PFlbdINbr4kT/bjxYb4isw5nDbGj9+n+RHWg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-21.2.19.tgz",
+      "integrity": "sha512-UVyUIj04LRBoi4KfvxeZYPohzh80nSqamxpb8uzsYFKVSYdZSHDiFaE6OOzj0YST1rs2/LC92cPE2TY7IQIdew==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0",
@@ -740,10 +740,10 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.17",
-        "@angular/compiler": "21.2.17",
-        "@angular/core": "21.2.17",
-        "@angular/platform-browser": "21.2.17",
+        "@angular/common": "21.2.19",
+        "@angular/compiler": "21.2.19",
+        "@angular/core": "21.2.19",
+        "@angular/platform-browser": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -8394,9 +8394,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8835,9 +8835,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9155,9 +9155,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10565,9 +10565,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Security Audit Fix

**Status:** Auto-fixes applied via npm audit fix. Two packages require manual intervention.

**Vulnerabilities found:**
- `@angular/common` [HIGH] — https://github.com/advisories/GHSA-jhpw-976m-542j
- `@angular/compiler` [HIGH] — https://github.com/advisories/GHSA-jj27-h5hq-8x99
- `@angular/core` [HIGH] — https://github.com/advisories/GHSA-jj27-h5hq-8x99
- `@angular/platform-server` [HIGH] — https://github.com/advisories/GHSA-vpx6-8pjr-4g3v
- `fast-uri` [HIGH] — https://github.com/advisories/GHSA-7p8r-x3mc-p8w7
- `ip-address` [HIGH] — https://github.com/advisories/GHSA-mwp4-54f8-5fhr, https://github.com/advisories/GHSA-4xrf-jv44-h6hh, https://github.com/advisories/GHSA-22jq-vg5j-6vgg
- `postcss` [HIGH] — https://github.com/advisories/GHSA-r28c-9q8g-f849, https://github.com/advisories/GHSA-fxqj-rqcc-2cmp *(no auto-fix)*
- `undici` [HIGH] — https://github.com/advisories/GHSA-8xcm-r25x-g524, https://github.com/advisories/GHSA-4cwx-7wf7-3272, https://github.com/advisories/GHSA-m8rv-5g2x-5cg5, https://github.com/advisories/GHSA-jr45-8vmc-qm54, https://github.com/advisories/GHSA-v3r7-h72x-cjcm *(no auto-fix)*

**Manual fixes still needed:**
- `postcss` — no semver-compatible fix available; check for a patch or pin a safe version manually
- `undici` — no auto-fix available; check Angular upstream for a patched transitive version

Generated by /security-scan agent.