### PR TITLE
chore(deps): security audit fix 2026-08-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9492,9 +9492,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Security Audit Fix

**Status:** Auto-fixes applied via npm audit fix.

**Vulnerabilities found:**
- `js-yaml` [HIGH] — https://github.com/advisories/GHSA-5p4m-2wfm-xmqj
- `undici` [HIGH] — https://github.com/advisories/GHSA-8xcm-r25x-g524, https://github.com/advisories/GHSA-4cwx-7wf7-3272, https://github.com/advisories/GHSA-m8rv-5g2x-5cg5, https://github.com/advisories/GHSA-jr45-8vmc-qm54, https://github.com/advisories/GHSA-v3r7-h72x-cjcm

**Manual fixes still needed:**
- `undici` (via `@angular-devkit/build-angular`) → bump `@angular-devkit/build-angular` to `22.1.3` (semver major)

Generated by /security-scan agent.