### PR TITLE
chore(deps): security audit fix 2026-08-08

### DIFF
--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -1,0 +1,26 @@
+# Security Audit Report
+
+Generated: 2026-08-08
+
+## HIGH vulnerabilities requiring manual semver-major upgrades
+
+All fixes require `npm audit fix --force` (breaking changes).
+
+| Package | Severity | Advisory |
+|---------|----------|---------|
+| `image-size` | HIGH | https://github.com/advisories/GHSA-w3rx-r6r6-pgpr |
+| `image-size` | HIGH | https://github.com/advisories/GHSA-5p2g-fcmc-qvqq |
+| `less` | HIGH | (depends on image-size) |
+| `undici` | HIGH | https://github.com/advisories/GHSA-8xcm-r25x-g524 |
+| `undici` | HIGH | https://github.com/advisories/GHSA-4cwx-7wf7-3272 |
+| `undici` | HIGH | https://github.com/advisories/GHSA-m8rv-5g2x-5cg5 |
+| `undici` | HIGH | https://github.com/advisories/GHSA-jr45-8vmc-qm54 |
+| `undici` | HIGH | https://github.com/advisories/GHSA-v3r7-h72x-cjcm |
+| `@angular-devkit/build-angular` | HIGH | (depends on above) |
+
+## Remediation
+
+Run `npm audit fix --force` to apply breaking-change upgrades:
+- `@angular-devkit/build-angular` → `22.1.3`
+
+Verify the app builds and works correctly after upgrading.


### PR DESCRIPTION
## Security Audit Fix

**Status:** No auto-fixes available — manual semver major bumps required. Audit report added as `SECURITY-AUDIT.md`.

**Vulnerabilities found:**
- `image-size` (HIGH) — DoS via infinite loop — https://github.com/advisories/GHSA-w3rx-r6r6-pgpr, https://github.com/advisories/GHSA-5p2g-fcmc-qvqq
- `less` (HIGH) — depends on vulnerable `image-size`
- `undici` (HIGH) — multiple: CRLF injection, cache poisoning, cookie injection — https://github.com/advisories/GHSA-8xcm-r25x-g524, https://github.com/advisories/GHSA-4cwx-7wf7-3272, https://github.com/advisories/GHSA-m8rv-5g2x-5cg5, https://github.com/advisories/GHSA-jr45-8vmc-qm54, https://github.com/advisories/GHSA-v3r7-h72x-cjcm
- `@angular-devkit/build-angular` (HIGH) — depends on vulnerable packages above

**Manual fixes still needed:**
- Run `npm audit fix --force` after reviewing breaking changes
- `@angular-devkit/build-angular` → `22.1.3` (semver major)
- Verify app builds and works after upgrading

Generated by /security-scan agent.