### PR TITLE
chore(deps): security audit fix 2026-08-09

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10565,16 +10565,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
@@ -13041,13 +13031,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "@types/express": "^5.0.6",
     "@types/node": "^22.0.0",
     "typescript": "~5.9.3"
+  },
+  "overrides": {
+    "undici": ">=7.29.0"
   }
 }


### PR DESCRIPTION
## Security Audit Fix

**Status:** Auto-fix applied for 1/4 HIGH vulnerabilities. 3 HIGH have no released upstream fix (all in build-time `image-size` chain).

**Vulnerabilities fixed:**

| Package | Severity | Advisory | Fix Applied |
|---------|----------|----------|-------------|
| undici | high | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524), [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272), [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5), [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54), [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) — CRLF injection, cookie injection, info disclosure | Added `overrides.undici: >=7.29.0` |

**Manual fixes still needed:**

| Package | Severity | Advisory | Action Required |
|---------|----------|----------|-----------------|
| image-size | high | [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) — DoS via infinite loops in ICNS/JXL/HEIF parsers | ⚠️ No released fix (all versions ≤2.0.2 are in the vulnerable range — build-time dep only) |
| less | high | (depends on image-size) | Resolves once image-size is patched |
| @angular-devkit/build-angular | high | (depends on less) | Resolves once image-size is patched |

Generated by /security-scan agent.