### PR TITLE
chore(deps): security audit fix 2026-08-13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,17 +275,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "21.2.20",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.20.tgz",
-      "integrity": "sha512-ungbjySjh+4F+3okIKf1XydY+zXl59djXqK9YiAdaLGDex1RaC0nkd7TckVAmVEJR/dJHtqT9heHgFnmrLPgSg==",
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.21.tgz",
+      "integrity": "sha512-Q9ee1UrdQcv2pVDyPn8sOUryZfvPQ7ItuXLCnzfqTW9Cm/dvY9oRmBbw8+Ae85FjVuPEvGBkGFcZqBp2hgBy8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.20",
-        "@angular-devkit/build-webpack": "0.2102.20",
-        "@angular-devkit/core": "21.2.20",
-        "@angular/build": "21.2.20",
+        "@angular-devkit/architect": "0.2102.21",
+        "@angular-devkit/build-webpack": "0.2102.21",
+        "@angular-devkit/core": "21.2.21",
+        "@angular/build": "21.2.21",
         "@babel/core": "7.29.7",
         "@babel/generator": "7.29.1",
         "@babel/helper-annotate-as-pure": "7.27.3",
@@ -296,7 +296,7 @@
         "@babel/preset-env": "7.29.2",
         "@babel/runtime": "7.29.2",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "21.2.20",
+        "@ngtools/webpack": "21.2.21",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.27",
         "babel-loader": "10.0.0",
@@ -351,7 +351,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.20",
+        "@angular/ssr": "^21.2.21",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^30.2.0",
@@ -407,14 +407,61 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2102.20",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.20.tgz",
-      "integrity": "sha512-ULSeZIELAwJuXTMuNh43IH4Xu9MLlsGPQnqXJawwH5Efc5lOT9adCKC9IHMzdKIDTFf/cldWabgEdCaMQR26WQ==",
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
+      "version": "0.2102.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.21.tgz",
+      "integrity": "sha512-WqITVviALevNpCQoI50e3YY9qNOQT+gqTow/4FhWsxlAJFMb5uyilFpVz2hGYWPgosF3OAKmT1h9r+Jm9S6SUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.20",
+        "@angular-devkit/core": "21.2.21",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.21.tgz",
+      "integrity": "sha512-xOr6mZ00M6hgM/xltAVkPVc/Yd1a/Wa0CGecV64JTITaVaSH8p8+wXe62Xavdr3pcc9cLKKUUB4mAup4k7Kkyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.2",
+        "source-map": "0.7.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack": {
+      "version": "0.2102.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.21.tgz",
+      "integrity": "sha512-UQ9hl4cVLLPr53GYr2GBrdR8NWT5/ncD/0Kwomc2kbAfIKni8QWHgn6pK1q0vZfQRJ/uy5N/dInrEPYRZhr+iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": "0.2102.21",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -425,6 +472,53 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^5.0.2"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
+      "version": "0.2102.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.21.tgz",
+      "integrity": "sha512-WqITVviALevNpCQoI50e3YY9qNOQT+gqTow/4FhWsxlAJFMb5uyilFpVz2hGYWPgosF3OAKmT1h9r+Jm9S6SUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "21.2.21",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.21.tgz",
+      "integrity": "sha512-xOr6mZ00M6hgM/xltAVkPVc/Yd1a/Wa0CGecV64JTITaVaSH8p8+wXe62Xavdr3pcc9cLKKUUB4mAup4k7Kkyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.2",
+        "source-map": "0.7.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -475,14 +569,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "21.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.20.tgz",
-      "integrity": "sha512-Dl9AX8e3mQpAl4RkmvoNnYRoRSpqMLQBqJYf/quupGLxMpQ55mOBhnGfzmoBLyETFhMUd329tvGtOcicPW/hdA==",
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.21.tgz",
+      "integrity": "sha512-Z88uTaPte8uEYW+Sn5BUz7YoGAbi1dcoz8X1eaJi30bT7qtZ5Bph0vELMBu2VCtp9JFgZhsLn+uy8F6iIPiOUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.20",
+        "@angular-devkit/architect": "0.2102.21",
         "@babel/core": "7.29.7",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -505,7 +599,7 @@
         "semver": "7.7.4",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.15",
-        "undici": "7.28.0",
+        "undici": "7.29.0",
         "vite": "7.3.6",
         "watchpack": "2.5.1"
       },
@@ -525,7 +619,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.20",
+        "@angular/ssr": "^21.2.21",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^21.0.0",
@@ -570,6 +664,53 @@
           "optional": true
         },
         "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/build/node_modules/@angular-devkit/architect": {
+      "version": "0.2102.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.21.tgz",
+      "integrity": "sha512-WqITVviALevNpCQoI50e3YY9qNOQT+gqTow/4FhWsxlAJFMb5uyilFpVz2hGYWPgosF3OAKmT1h9r+Jm9S6SUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "21.2.21",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/build/node_modules/@angular-devkit/core": {
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.21.tgz",
+      "integrity": "sha512-xOr6mZ00M6hgM/xltAVkPVc/Yd1a/Wa0CGecV64JTITaVaSH8p8+wXe62Xavdr3pcc9cLKKUUB4mAup4k7Kkyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.2",
+        "source-map": "0.7.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
           "optional": true
         }
       }
@@ -4501,9 +4642,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
-      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4518,14 +4659,14 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "21.2.20",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.20.tgz",
-      "integrity": "sha512-6UQlsKYdPoINJA07dNWP505rru0gJ08oP8O3H6XHW1H0jEj04e498IMNgoKqw4ZTREExhOX3Zts693hAaASABA==",
+      "version": "21.2.21",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.21.tgz",
+      "integrity": "sha512-Nm5Diu+IrXL6/Wg+lA1MB57K1Y4aUOyKkGvJ5rGbvmdSML1dsSwsya2ilpho/FNu3RaGsJfxEwS8qwA+RhcYTg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Security Audit Fix

**Status:** Auto-fixes partially applied via `npm audit fix` (package-lock.json updated). HIGH vulnerabilities remain — manual semver major upgrades required.

**Vulnerabilities found (3 HIGH):**

- **@angular-devkit/build-angular** (HIGH) — transitive via `image-size` and `less`
- **image-size** (HIGH)
  - [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) — ICNS parser DoS via infinite loop
  - [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) — JXL/HEIF parser DoS via infinite loops
- **less** (HIGH) — transitive via `@angular-devkit/build-angular`

**Manual fixes still needed:**

All 3 vulnerabilities require upgrading `@angular-devkit/build-angular` to **v22.1.3** (semver major bump). Run: `ng update @angular/core @angular/cli`

Generated by /security-scan agent.