### PR TITLE
chore(deps): security audit fix 2026-08-14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10568,9 +10568,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Security Audit Fix

**Status:** Partial auto-fix applied via `npm audit fix`. Manual semver bumps still required.

**Vulnerabilities found:**
- `nanoid` [HIGH] — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) ✅ auto-fixed
- `image-size` [HIGH] — [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) ⚠️ manual fix needed
- `@angular-devkit/build-angular` [HIGH] ⚠️ manual fix needed
- `less` [HIGH] ⚠️ manual fix needed (transitive via Angular build)

**Manual fixes still needed:**
- Upgrade `@angular-devkit/build-angular` from current → v22.1.4 (semver major bump). This will also resolve `image-size` and `less` transitively.

Generated by /security-scan agent.